### PR TITLE
Fix legacy dispute evidence as String

### DIFF
--- a/tap_stripe/schemas/disputes.json
+++ b/tap_stripe/schemas/disputes.json
@@ -60,8 +60,7 @@
     "evidence": {
       "type": [
         "null",
-        "object",
-        "string"
+        "object"
       ],
       "properties": {
         "refund_policy": {
@@ -146,6 +145,12 @@
           "type": ["null", "string"]
         }
       }
+    },
+    "evidence_legacy": {
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "evidence_details": {
       "type": [


### PR DESCRIPTION
# Description of change
 - Detect when dispute evidence is a string and save to another key on the record ("evidence_legacy"). 

# Manual QA steps
 - Tested by running the tap
 
# Risks
 - N/AA
 
# Rollback steps
 - revert this branch
