### PR TITLE
Account Pagination Tweaks

### DIFF
--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -456,10 +456,6 @@ def paginate(sdk_obj, filter_key, start_date, end_date, limit=100):
         _context_account = [sdk_obj.retrieve(Context.config.get('account_id'))]
         yield from _context_account
 
-        # For account stream we should retrieve all accounts each time
-        # as a consistent replication key does not exist.
-        filters = {}
-
         # As accounts is not using a replication range on each call, using
         # limit=100 produces a 500 error from Stripe. Suspect this is due to the
         # amount of data in the response, so a lower limit will work to mitigate

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -464,7 +464,7 @@ def paginate(sdk_obj, filter_key, start_date, end_date, limit=100):
         # limit=100 produces a 500 error from Stripe. Suspect this is due to the
         # amount of data in the response, so a lower limit will work to mitigate
         # this, it just means more network calls to the API.
-        limit = 20
+        limit = 80
 
     yield from sdk_obj.list(
         limit=limit, stripe_account=Context.config.get('account_id'), **filters

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -464,7 +464,7 @@ def paginate(sdk_obj, filter_key, start_date, end_date, limit=100):
         # limit=100 produces a 500 error from Stripe. Suspect this is due to the
         # amount of data in the response, so a lower limit will work to mitigate
         # this, it just means more network calls to the API.
-        limit = 40
+        limit = 20
 
     yield from sdk_obj.list(
         limit=limit, stripe_account=Context.config.get('account_id'), **filters


### PR DESCRIPTION
# Description of change
(write a short description or paste a link to JIRA)

- Bumps API limit to 80 (no problems seen in testing)
- Use bookmark / start_date for accounts stream.

# Manual QA steps
 - Tested on an test env, no problems detected.
 
# Risks
 - N/A
 
# Rollback steps
 - Revert this branch
