### PR TITLE
Handle Stripe events API 30 day limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.virtualenv/
 
 # Spyder project settings
 .spyderproject
@@ -96,6 +97,7 @@ ENV/
 env.sh
 config.json
 .autoenv.zsh
+.idea/
 
 rsa-key
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ ENV/
 # Custom stuff
 env.sh
 config.json
+catalog.json
 .autoenv.zsh
 .idea/
 

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -515,7 +515,7 @@ def sync_stream(stream_name):
         sub_stream_bookmark = None
 
     with Transformer(singer.UNIX_SECONDS_INTEGER_DATETIME_PARSING) as transformer:
-        if Context.config["end_date"]:
+        if Context.config.get('end_date'):
             end_time = int(
                 utils.strptime_to_utc(Context.config["end_date"]).timestamp()
             )
@@ -841,11 +841,11 @@ def sync_event_updates(stream_name):
     max_created_dt = datetime.fromtimestamp(max_created, timezone.utc)
     max_created_dt_limit = utils.now() - timedelta(days=30)
     if max_created_dt < max_created_dt_limit:
-        max_created = max_created_dt_limit.timestamp()
+        max_created = int(max_created_dt_limit.timestamp())
 
     date_window_start = max_created
 
-    if Context.config["end_date"]:
+    if Context.config.get('end_date'):
         date_window_end = int(
             utils.strptime_to_utc(Context.config["end_date"]).timestamp()
         )

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -509,7 +509,7 @@ def sync_stream(stream_name):
     ) or int(utils.strptime_to_utc(Context.config["start_date"]).timestamp())
     bookmark = stream_bookmark
     if stream_name == 'events':
-        bookmark = confine_events_start_date(bookmark)
+        bookmark = _confine_events_start_date(bookmark)
 
     # if this stream has a sub_stream, compare the bookmark
     sub_stream_name = SUB_STREAMS.get(stream_name)
@@ -841,7 +841,7 @@ def recursive_to_dict(some_obj):
     return some_obj
 
 
-def confine_events_start_date(start_date: Union[int, float]):
+def _confine_events_start_date(start_date: Union[int, float]):
     # Stripe events API only saves the last 30 days of history.
     # So we ensure when we call the API we only go back 30 days at max.
 
@@ -868,7 +868,7 @@ def sync_event_updates(stream_name):
     ) or int(utils.strptime_to_utc(Context.config["start_date"]).timestamp())
     max_created = bookmark_value
 
-    date_window_start = confine_events_start_date(max_created)
+    date_window_start = _confine_events_start_date(max_created)
 
     if Context.config.get('end_date'):
         date_window_end = int(

--- a/tap_stripe/__init__.py
+++ b/tap_stripe/__init__.py
@@ -5,6 +5,8 @@ import os
 import re
 from datetime import datetime, timedelta, timezone
 
+from typing import Union
+
 import stripe
 import stripe.error
 from stripe.stripe_object import StripeObject
@@ -141,9 +143,9 @@ class Context:
 
     @classmethod
     def get_schema(cls, stream_name):
-        stream = [s for s in cls.catalog["streams"] if s["tap_stream_id"] == stream_name][
-            0
-        ]
+        stream = [
+            s for s in cls.catalog["streams"] if s["tap_stream_id"] == stream_name
+        ][0]
         return stream["schema"]
 
     @classmethod
@@ -215,7 +217,10 @@ def configure_stripe_client():
     logging.getLogger('stripe').setLevel(logging.INFO)
     # Verify connectivity
     account = stripe.Account.retrieve(Context.config.get('account_id'))
-    LOGGER.info("Successfully connected to Stripe Account with name `%s`", account.business_profile.name)
+    LOGGER.info(
+        "Successfully connected to Stripe Account with name `%s`",
+        account.business_profile.name,
+    )
 
 
 def unwrap_data_objects(rec):
@@ -257,14 +262,17 @@ class DependencyException(Exception):
 def validate_dependencies():
     errs = []
     msg_tmpl = (
-        "Unable to extract {0} data. " "To receive {0} data, you also need to select {1}."
+        "Unable to extract {0} data. "
+        "To receive {0} data, you also need to select {1}."
     )
 
     for catalog_entry in Context.catalog['streams']:
         stream_id = catalog_entry['tap_stream_id']
         sub_stream_id = SUB_STREAMS.get(stream_id)
         if sub_stream_id:
-            if Context.is_selected(sub_stream_id) and not Context.is_selected(stream_id):
+            if Context.is_selected(sub_stream_id) and not Context.is_selected(
+                stream_id
+            ):
                 # throw error here
                 errs.append(msg_tmpl.format(sub_stream_id, stream_id))
 
@@ -299,7 +307,9 @@ def load_schemas():
 
     schema_path = get_abs_path('schemas')
     files = [
-        f for f in os.listdir(schema_path) if os.path.isfile(os.path.join(schema_path, f))
+        f
+        for f in os.listdir(schema_path)
+        if os.path.isfile(os.path.join(schema_path, f))
     ]
     for filename in files:
         path = get_abs_path('schemas') + '/' + filename
@@ -483,7 +493,9 @@ def sync_stream(stream_name):
     """
     LOGGER.info("Started syncing stream %s", stream_name)
 
-    stream_metadata = metadata.to_map(Context.get_catalog_entry(stream_name)['metadata'])
+    stream_metadata = metadata.to_map(
+        Context.get_catalog_entry(stream_name)['metadata']
+    )
     stream_field_whitelist = json.loads(Context.config.get('whitelist_map', '{}')).get(
         stream_name
     )
@@ -496,6 +508,8 @@ def sync_stream(stream_name):
         Context.state, stream_name, replication_key
     ) or int(utils.strptime_to_utc(Context.config["start_date"]).timestamp())
     bookmark = stream_bookmark
+    if stream_name == 'events':
+        bookmark = confine_events_start_date(bookmark)
 
     # if this stream has a sub_stream, compare the bookmark
     sub_stream_name = SUB_STREAMS.get(stream_name)
@@ -609,7 +623,9 @@ def sync_stream(stream_name):
                     if stream_field_whitelist:
                         rec = apply_whitelist(rec, stream_field_whitelist)
 
-                    singer.write_record(stream_name, rec, time_extracted=extraction_time)
+                    singer.write_record(
+                        stream_name, rec, time_extracted=extraction_time
+                    )
 
                     Context.new_counts[stream_name] += 1
 
@@ -780,7 +796,9 @@ def sync_sub_stream(sub_stream_name, parent_obj, updates=False):
                 # Ensure the account ID is added to the rec
                 rec['account_id'] = Context.config.get('account_id')
 
-                singer.write_record(sub_stream_name, rec, time_extracted=extraction_time)
+                singer.write_record(
+                    sub_stream_name, rec, time_extracted=extraction_time
+                )
             if updates:
                 Context.updated_counts[sub_stream_name] += 1
             else:
@@ -823,12 +841,26 @@ def recursive_to_dict(some_obj):
     return some_obj
 
 
+def confine_events_start_date(start_date: Union[int, float]):
+    # Stripe events API only saves the last 30 days of history.
+    # So we ensure when we call the API we only go back 30 days at max.
+
+    max_created = start_date
+
+    max_created_dt = datetime.fromtimestamp(max_created, timezone.utc)
+    max_created_dt_limit = utils.now() - timedelta(days=30)
+    if max_created_dt < max_created_dt_limit:
+        max_created = max_created_dt_limit.timestamp()
+
+    return int(max_created)
+
+
 def sync_event_updates(stream_name):
-    '''
+    """
     Get updates via events endpoint
 
     look at 'events update' bookmark and pull events after that
-    '''
+    """
     LOGGER.info("Started syncing event based updates")
 
     bookmark_value = singer.get_bookmark(
@@ -836,14 +868,7 @@ def sync_event_updates(stream_name):
     ) or int(utils.strptime_to_utc(Context.config["start_date"]).timestamp())
     max_created = bookmark_value
 
-    # Stripe events API only saves the last 30 days of history.
-    # So we ensure when we call the API we only go back 30 days at max.
-    max_created_dt = datetime.fromtimestamp(max_created, timezone.utc)
-    max_created_dt_limit = utils.now() - timedelta(days=30)
-    if max_created_dt < max_created_dt_limit:
-        max_created = int(max_created_dt_limit.timestamp())
-
-    date_window_start = max_created
+    date_window_start = confine_events_start_date(max_created)
 
     if Context.config.get('end_date'):
         date_window_end = int(
@@ -891,7 +916,9 @@ def sync_event_updates(stream_name):
                 continue
 
             # Syncing an event as its the first time we've seen it or its the most recent version
-            with Transformer(singer.UNIX_SECONDS_INTEGER_DATETIME_PARSING) as transformer:
+            with Transformer(
+                singer.UNIX_SECONDS_INTEGER_DATETIME_PARSING
+            ) as transformer:
                 event_resource_metadata = metadata.to_map(
                     Context.get_catalog_entry(stream_name)['metadata']
                 )


### PR DESCRIPTION
# Description of change

On January 20, 2021, Stripe will change how we provide our Events API: you will no longer be able to retrieve Events older than 30 days

# Manual QA steps
 - Run the tap manually.
 
# Risks
 - Breaks the tap.
 
# Rollback steps
 - revert this branch
